### PR TITLE
Create the emission spectrum for the WLS plates outside of the Steppi…

### DIFF
--- a/WCSim.cc
+++ b/WCSim.cc
@@ -97,6 +97,8 @@ int main(int argc,char** argv)
 
   runManager->SetUserAction(new WCSimSteppingAction(myRunAction));
 
+  // Create the emission spectrum for the WLS plate
+  CreateEmissionHistogram();
 
   // Initialize G4 kernel
   runManager->Initialize();

--- a/include/WCSimSteppingAction.hh
+++ b/include/WCSimSteppingAction.hh
@@ -10,6 +10,8 @@
 class G4HCofThisEvent;
 class G4Event;
 
+inline void CreateEmissionHistogram();
+
 class WCSimSteppingAction : public G4UserSteppingAction
 {
  private:


### PR DESCRIPTION
…ngAction class. Will be created once and used in SteppingAction to increase speed of simulation.