### PR TITLE
Vector files can now be used. Changed variable names to avoid conflicts.

### DIFF
--- a/include/WCSimPrimaryGeneratorMessenger.hh
+++ b/include/WCSimPrimaryGeneratorMessenger.hh
@@ -25,6 +25,7 @@ class WCSimPrimaryGeneratorMessenger: public G4UImessenger
   G4UIdirectory*      mydetDirectory;
   G4UIcmdWithAString* genCmd;
   G4UIcmdWithAString* fileNameCmd;
+  G4UIcmdWithAString* fileNameCmdCosmics;
   
 };
 

--- a/src/WCSimPrimaryGeneratorAction.cc
+++ b/src/WCSimPrimaryGeneratorAction.cc
@@ -79,20 +79,20 @@ WCSimPrimaryGeneratorAction::WCSimPrimaryGeneratorAction(
 
   // Create the relevant histograms to generate muons
   // according to SuperK flux extrapolated at HyperK site
-  std::fstream inputFile;
-  G4String vectorFileName;
+  std::fstream inputFileCosmics;
+  G4String vectorFileNameCosmics;
   altCosmics = 2*myDC->GetWCIDHeight();
   G4cout << "altCosmics : " << altCosmics << G4endl;
-  if (inputFile.is_open())
-    inputFile.close();
+  if (inputFileCosmics.is_open())
+    inputFileCosmics.close();
 
-  vectorFileName = "MuonFlux-HyperK-ThetaPhi.dat";
-  inputFile.open(vectorFileName, std::fstream::in);
+  vectorFileNameCosmics = "MuonFlux-HyperK-ThetaPhi.dat";
+  inputFileCosmics.open(vectorFileNameCosmics, std::fstream::in);
 
-  if (!inputFile.is_open()) {
-    G4cout << "Muon Vector file " << vectorFileName << " not found" << G4endl;
+  if (!inputFileCosmics.is_open()) {
+    G4cout << "Muon Vector file " << vectorFileNameCosmics << " not found" << G4endl;
   } else {
-    G4cout << "Muon Vector file " << vectorFileName << " found" << G4endl;
+    G4cout << "Muon Vector file " << vectorFileNameCosmics << " found" << G4endl;
     string line;
     vector<string> token(1);
 
@@ -109,7 +109,7 @@ WCSimPrimaryGeneratorAction::WCSimPrimaryGeneratorAction(
     hEmeanCosmics->GetXaxis()->SetTitle("#phi (deg)");
     hEmeanCosmics->GetYaxis()->SetTitle("cos #theta");
 
-    while ( getline(inputFile,line) ){
+    while ( getline(inputFileCosmics,line) ){
       token = tokenize(" $", line);
 
       binCos=(atof(token[0]));

--- a/src/WCSimPrimaryGeneratorMessenger.cc
+++ b/src/WCSimPrimaryGeneratorMessenger.cc
@@ -25,11 +25,11 @@ WCSimPrimaryGeneratorMessenger::WCSimPrimaryGeneratorMessenger(WCSimPrimaryGener
   fileNameCmd->SetParameterName("fileName",true);
   fileNameCmd->SetDefaultValue("inputvectorfile");
 
-  fileNameCmd = new G4UIcmdWithAString("/mygen/cosmicsfile",this);
-  fileNameCmd->SetGuidance("Select the file of cosmics.");
-  fileNameCmd->SetGuidance(" Enter the file name of the cosmics file");
-  fileNameCmd->SetParameterName("fileName",true);
-  fileNameCmd->SetDefaultValue("inputvectorfile");
+  fileNameCmdCosmics = new G4UIcmdWithAString("/mygen/cosmicsfile",this);
+  fileNameCmdCosmics->SetGuidance("Select the file of cosmics.");
+  fileNameCmdCosmics->SetGuidance(" Enter the file name of the cosmics file");
+  fileNameCmdCosmics->SetParameterName("fileName",true);
+  fileNameCmdCosmics->SetDefaultValue("inputvectorfile");
 
 }
 
@@ -85,7 +85,7 @@ void WCSimPrimaryGeneratorMessenger::SetNewValue(G4UIcommand * command,G4String 
     }
   }
 
-  if( command == fileNameCmd )
+  if( command == fileNameCmd || command == fileNameCmdCosmics )
   {
     myAction->OpenVectorFile(newValue);
     G4cout << "Input vector file set to " << newValue << G4endl;


### PR DESCRIPTION
So I have been unable to get nuance vector files to work and I have just found that it is because the messenger command is overwritten by the cosmics command.