### PR TITLE
Add od info

### DIFF
--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -84,6 +84,7 @@ public:
   G4double GetWaterTubeLength()   {return WCLength;}
   G4double GetWaterTubePosition() {return WCPosition;}
   G4double GetPMTSize()           {return WCPMTRadius;}
+  G4double GetODPMTSize()           {return WCPMTODRadius;}
   G4String GetPMTName()			  {return WCPMTName;}
   G4int    GetMyConfiguration()   {return myConfiguration;}
   G4double GetGeo_Dm(G4int);

--- a/include/WCSimRootGeom.hh
+++ b/include/WCSimRootGeom.hh
@@ -58,6 +58,8 @@ private:
 
   Float_t                fWCPMTRadius; // Radius of PMT
   Int_t                  fWCNumPMT;   // Number of PMTs
+  Float_t                fODWCPMTRadius; // Radius of PMT
+  Int_t                  fODWCNumPMT;   // Number of PMTs
   Float_t                fWCOffset[3]; // Offset of barrel center in global coords
   Int_t                  fOrientation; //Orientation o detector, 0 is 2km horizontal, 1 is Upright
 
@@ -79,7 +81,9 @@ public:
   void SetGeo_Type(Int_t f){fgeo_type = f;}
 
   void  SetWCNumPMT(Int_t i) {fWCNumPMT= i;}
+  void  SetODWCNumPMT(Int_t i) {fODWCNumPMT= i;}
   void  SetWCPMTRadius(Float_t f) {fWCPMTRadius = f;}
+  void  SetODWCPMTRadius(Float_t f) {fODWCPMTRadius = f;}
   void  SetWCOffset(Float_t x, Float_t y, Float_t z) 
            {fWCOffset[0]=x; fWCOffset[1]=y; fWCOffset[2] = z;}
   void  SetPMT(Int_t i, Int_t tubeno, Int_t cyl_loc, Float_t rot[3], Float_t pos[3], bool expand=true);
@@ -92,7 +96,9 @@ public:
   
 
   Int_t GetWCNumPMT() const {return fWCNumPMT;}
+  Int_t GetODWCNumPMT() const {return fODWCNumPMT;}
   Float_t GetWCPMTRadius() const {return fWCPMTRadius;}
+  Float_t GetODWCPMTRadius() const {return fODWCPMTRadius;}
   Float_t GetWCOffset(Int_t i) const {return (i<3) ? fWCOffset[i] : 0.;}
   Int_t GetOrientation() { return fOrientation; }
   //WCSimRootPMT GetPMT(Int_t i){return *(new WCSimRootPMT());}

--- a/src/WCSimConstructGeometryTables.cc
+++ b/src/WCSimConstructGeometryTables.cc
@@ -220,9 +220,9 @@ void WCSimDetectorConstruction::DumpGeometryTableToFile()
     // print key: 0-top, 1-barrel, 2-bottom, 
  //   if (pmtOrientation*newTransform.getTranslation() > 0)//veto pmt
   //  {cylLocation=3;}
-    if (pmtOrientation.z()==1.0)// top 
+    if (pmtOrientation.z()==1.0)// bottom 
     {cylLocation=2;}
-    else if (pmtOrientation.z()==-1.0)// bottom 
+    else if (pmtOrientation.z()==-1.0)// top 
     {cylLocation=0;}
     else // barrel
     {cylLocation=1;}
@@ -269,9 +269,9 @@ void WCSimDetectorConstruction::DumpGeometryTableToFile()
     // TODO: make these record something sensible for the OD, 3-topOD, 4-barrelOD, 5-bottomOD
 //    if (pmtOrientation*newTransform.getTranslation() > 0)//veto pmt
 //    {cylLocation=3;}
-    if (pmtOrientation.z()==1.0)//bottom OD
+    if (pmtOrientation.z()==1.0)//top OD
     {cylLocation=5;}
-    else if (pmtOrientation.z()==-1.0)//top OD
+    else if (pmtOrientation.z()==-1.0)//bottom OD
     {cylLocation=3;}
     else // barrel OD
     {cylLocation=4;}

--- a/src/WCSimConstructGeometryTables.cc
+++ b/src/WCSimConstructGeometryTables.cc
@@ -217,12 +217,12 @@ void WCSimDetectorConstruction::DumpGeometryTableToFile()
     //cyl_location cylLocation = tubeCylLocation[tubeID];
 
     // Figure out if pmt is on top/bottom or barrel
-    // print key: 0-top, 1-barrel, 2-bottom
-    if (pmtOrientation*newTransform.getTranslation() > 0)//veto pmt
-    {cylLocation=3;}
-    else if (pmtOrientation.z()==1.0)//bottom
+    // print key: 0-top, 1-barrel, 2-bottom, 
+ //   if (pmtOrientation*newTransform.getTranslation() > 0)//veto pmt
+  //  {cylLocation=3;}
+    if (pmtOrientation.z()==1.0)// top 
     {cylLocation=2;}
-    else if (pmtOrientation.z()==-1.0)//top
+    else if (pmtOrientation.z()==-1.0)// bottom 
     {cylLocation=0;}
     else // barrel
     {cylLocation=1;}
@@ -266,15 +266,15 @@ void WCSimDetectorConstruction::DumpGeometryTableToFile()
     G4Vector3D pmtOrientation = newTransform * nullOrient;
     //cyl_location cylLocation = tubeCylLocation[tubeID];
 
-    // TODO: make these record something sensible for the OD
-    if (pmtOrientation*newTransform.getTranslation() > 0)//veto pmt
+    // TODO: make these record something sensible for the OD, 3-topOD, 4-barrelOD, 5-bottomOD
+//    if (pmtOrientation*newTransform.getTranslation() > 0)//veto pmt
+//    {cylLocation=3;}
+    if (pmtOrientation.z()==1.0)//bottom OD
+    {cylLocation=5;}
+    else if (pmtOrientation.z()==-1.0)//top OD
     {cylLocation=3;}
-    else if (pmtOrientation.z()==1.0)//bottom
-    {cylLocation=2;}
-    else if (pmtOrientation.z()==-1.0)//top
-    {cylLocation=0;}
-    else // barrel
-    {cylLocation=1;}
+    else // barrel OD
+    {cylLocation=4;}
 
     geoFile.precision(9);
     geoFile << setw(4) << tubeID

--- a/src/WCSimRunAction.cc
+++ b/src/WCSimRunAction.cc
@@ -155,7 +155,9 @@ void WCSimRunAction::FillGeoTree(){
   G4int geo_type;
   G4double cylinfo[3];
   G4double pmtradius;
+  G4double pmtradiusOD;
   G4int numpmt;
+  G4int numpmtOD;
   G4int orientation;
   Float_t offset[3];
   
@@ -184,10 +186,14 @@ void WCSimRunAction::FillGeoTree(){
 
 
   pmtradius = wcsimdetector->GetPMTSize1();
+  pmtradiusOD = wcsimdetector->GetODPMTSize();
   numpmt = wcsimdetector->GetTotalNumPmts();
+  numpmtOD = wcsimdetector->GetTotalNumODPmts();
+
   orientation = 0;
   
   wcsimrootgeom-> SetWCPMTRadius(pmtradius);
+  wcsimrootgeom-> SetODWCPMTRadius(pmtradiusOD);
   wcsimrootgeom-> SetOrientation(orientation);
   
   G4ThreeVector offset1= wcsimdetector->GetWCOffset();
@@ -197,6 +203,7 @@ void WCSimRunAction::FillGeoTree(){
   wcsimrootgeom-> SetWCOffset(offset[0],offset[1],offset[2]);
   
   std::vector<WCSimPmtInfo*> *fpmts = wcsimdetector->Get_Pmts();
+  std::vector<WCSimPmtInfo*> *fODpmts = wcsimdetector->Get_ODPmts();
   WCSimPmtInfo *pmt;
   for (unsigned int i=0;i!=fpmts->size();i++){
     pmt = ((WCSimPmtInfo*)fpmts->at(i));
@@ -210,12 +217,29 @@ void WCSimRunAction::FillGeoTree(){
     cylLoc = pmt->Get_cylocation();
     wcsimrootgeom-> SetPMT(i,tubeNo,cylLoc,rot,pos);
   }
+  for (unsigned int i=0;i!=fODpmts->size();i++){
+    pmt = ((WCSimPmtInfo*)fODpmts->at(i));
+    pos[0] = pmt->Get_transx();
+    pos[1] = pmt->Get_transy();
+    pos[2] = pmt->Get_transz();
+    rot[0] = pmt->Get_orienx();
+    rot[1] = pmt->Get_orieny();
+    rot[2] = pmt->Get_orienz();
+    tubeNo = pmt->Get_tubeid();
+    cylLoc = pmt->Get_cylocation();
+    wcsimrootgeom-> SetPMT(i+fpmts->size(),tubeNo+fpmts->size(),cylLoc,rot,pos);
+  }
   if (fpmts->size() != (unsigned int)numpmt) {
-    G4cout << "Mismatch between number of pmts and pmt list in geofile.txt!!"<<G4endl;
+    G4cout << "Mismatch between number of id pmts and pmt list in geofile.txt!!"<<G4endl;
     G4cout << fpmts->size() <<" vs. "<< numpmt <<G4endl;
+  }
+  if (fODpmts->size() != (unsigned int)numpmtOD) {
+    G4cout << "Mismatch between number of od pmts and pmt list in geofile.txt!!"<<G4endl;
+    G4cout << fODpmts->size() <<" vs. "<< numpmtOD <<G4endl;
   }
   
   wcsimrootgeom-> SetWCNumPMT(numpmt);
+  wcsimrootgeom-> SetODWCNumPMT(numpmtOD);
   
   geoTree->Fill();
   geoTree->Write();


### PR DESCRIPTION
This commit adds the OD PMTs to the overall PMT array.  This commit also creates some functions to get the number of OD PMTs and the details of the PMTs. 

Keep in mind that the OD PMTs may share and tube id with an ID PMT, so the best way to get the info for the OD PMT is to use something like GetPMT(MaxNumIDPMTs + NumOFODPMT - 1). The -1 is because GetPMT reads from an array and so pmt 1 is in the array as number 0. 

This commit also adds the cylloc numbers which can be used to identify if the PMT is on the top cap, barrel or bottom cap (separate for ID and OD).